### PR TITLE
make pcre_printint build on macos

### DIFF
--- a/pcre_printint.c
+++ b/pcre_printint.c
@@ -56,7 +56,7 @@ asked to print out a compiled regex for debugging purposes. */
 #endif
 
 /* For pcretest program. */
-#define PRIV(name) name
+//#define PRIV(name) name
 
 /* We have to include pcre_internal.h because we need the internal info for
 displaying the results of pcre_study() and we also need to know about the


### PR DESCRIPTION
without this fix, this is what happens on macos:

```
MachO Flush... error(link): undefined reference to symbol '_utf8_table4'
error(link):   first referenced in '/Users/luna/git/awtfdb/zig-cache/o/037c0377d3bf6e36468df22ecf4d7242/pcre_printint.o'
error(link): undefined reference to symbol '_utt'
error(link):   first referenced in '/Users/luna/git/awtfdb/zig-cache/o/037c0377d3bf6e36468df22ecf4d7242/pcre_printint.o'
error(link): undefined reference to symbol '_ucd_caseless_sets'
error(link):   first referenced in '/Users/luna/git/awtfdb/zig-cache/o/037c0377d3bf6e36468df22ecf4d7242/pcre_printint.o'
error(link): undefined reference to symbol '_utf8_table3'
error(link):   first referenced in '/Users/luna/git/awtfdb/zig-cache/o/037c0377d3bf6e36468df22ecf4d7242/pcre_printint.o'
error(link): undefined reference to symbol '_utt_names'
error(link):   first referenced in '/Users/luna/git/awtfdb/zig-cache/o/037c0377d3bf6e36468df22ecf4d7242/pcre_printint.o'
error(link): undefined reference to symbol '_utt_size'
error(link):   first referenced in '/Users/luna/git/awtfdb/zig-cache/o/037c0377d3bf6e36468df22ecf4d7242/pcre_printint.o'
error: UndefinedSymbolReference
```

it looks like printint defining its own `PRIV` means it loses track of the real `PRIV` defined by `pcre_internal.h`, which has those symbols.

this does not break `x86_64-linux-gnu` AFAIK.